### PR TITLE
Added openssl-devel package to required package list

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,6 +18,7 @@
   - flex
   - bison
   - make
+  - openssl-devel
   - perl-ExtUtils-MakeMaker
   - perl-Digest-SHA
   - perl-Net-DNS


### PR DESCRIPTION
According to the DirectAdmin documentation you need to have "openssl-devel" package installed as well: https://www.directadmin.com/installguide.php